### PR TITLE
docs: Add GUI dependencies to README to improve portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,50 @@ Here is a list of the available calculators:
 | `significant_figures`       | Rounds a number to a specified number of significant figures.                                           |
 | `upperlower_bounds`         | Calculates the upper and lower bounds of a number that has been rounded to a certain degree of accuracy. |
 
-## How to Run a Calculator
+## GUI Application
 
-To run any of the calculators, use the `cargo run --bin` command, followed by the name of the calculator. For example, to run the BODMAS calculator, you would use the following command:
+In addition to the command-line tools, MathRust also provides a graphical user interface (GUI) that gives you access to all the calculators in a single window.
+
+### Platform-specific Dependencies
+
+To compile and run the GUI application, you may need to install some system dependencies.
+
+#### Linux
+
+On Linux, you need to have development libraries for either X11 or Wayland.
+
+For **Debian-based distributions (like Ubuntu)**, you can install the required packages with:
+
+```bash
+sudo apt install libx11-xcb-dev xinput libxcursor-dev libxkbcommon-x11-dev libx11-dev
+```
+
+For **Fedora/RHEL-based distributions**, you can use `dnf` to install similar packages (e.g., `libX11-devel`, `libxkbcommon-x11-devel`, etc.).
+
+#### Windows
+
+No additional system dependencies are required on Windows. You will only need the standard Rust toolchain for MSVC.
+
+#### macOS
+
+No additional system dependencies are required on macOS. Make sure you have the Xcode Command Line Tools installed.
+
+## How to Run
+
+### Command-line Calculators
+
+To run any of the command-line calculators, use the `cargo run --bin` command, followed by the name of the calculator. For example, to run the BODMAS calculator, you would use the following command:
 
 ```bash
 cargo run --bin bodmas_calculator
 ```
 
 You will then be prompted to enter your input.
+
+### GUI Application
+
+To run the GUI application, use the following command:
+
+```bash
+cargo run --bin gui
+```


### PR DESCRIPTION
This project includes a GUI application built with the `iced` crate. While the Rust code is cross-platform, the `iced` library has system-level dependencies that must be installed on certain operating systems for the GUI to compile and run.

This change updates the `README.md` to:
- Document the existence of the GUI application.
- Provide instructions for installing the necessary system dependencies on Linux, Windows, and macOS.
- Add instructions on how to run the GUI application.

These changes make the project more portable by ensuring that users have the information they need to get the application running on their specific OS.